### PR TITLE
Allow cookie expiry date to be set from a float

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -36,7 +36,7 @@ Signature: `Response.set_cookie(key, value, max_age=None, expires=None, path="/"
 * `key` - A string that will be the cookie's key.
 * `value` - A string that will be the cookie's value.
 * `max_age` - An integer that defines the lifetime of the cookie in seconds. A negative integer or a value of `0` will discard the cookie immediately. `Optional`
-* `expires` - An integer that defines the number of seconds until the cookie expires. `Optional`
+* `expires` - An integer or float (cast to an integer), that defines the number of seconds until the cookie expires. `Optional`
 * `path` - A string that specifies the subset of routes to which the cookie will apply. `Optional`
 * `domain` - A string that specifies the domain for which the cookie is valid. `Optional`
 * `secure` - A bool indicating that the cookie will only be sent to the server if request is made using SSL and the HTTPS protocol. `Optional`

--- a/starlette/responses.py
+++ b/starlette/responses.py
@@ -103,7 +103,7 @@ class Response:
         key: str,
         value: str = "",
         max_age: int = None,
-        expires: int = None,
+        expires: typing.Union[int, float] = None,
         path: str = "/",
         domain: str = None,
         secure: bool = False,
@@ -115,7 +115,7 @@ class Response:
         if max_age is not None:
             cookie[key]["max-age"] = max_age
         if expires is not None:
-            cookie[key]["expires"] = expires
+            cookie[key]["expires"] = int(expires)
         if path is not None:
             cookie[key]["path"] = path
         if domain is not None:

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -276,6 +276,82 @@ def test_set_cookie():
     assert response.text == "Hello, world!"
 
 
+def test_set_cookie_int():
+    import datetime as dt
+    conf = {
+        "key": "mycookie",
+        "value": "myvalue",
+        "max_age": 10,
+        "expires": 10,
+        "path": "/",
+        "domain": "localhost",
+        "secure": True,
+        "httponly": True,
+        "samesite": "none",
+    }
+
+    async def app(scope, receive, send):
+        response = Response("Hello, world!", media_type="text/plain")
+        response.set_cookie(
+            key=conf["key"],
+            value=conf["value"],
+            max_age=conf["max_age"],
+            expires=conf["expires"],
+            path=conf["path"],
+            domain=conf["domain"],
+            secure=conf["secure"],
+            httponly=conf["httponly"],
+            samesite=conf["samesite"],
+        )
+
+        await response(scope, receive, send)
+
+    client = TestClient(app)
+    response = client.get("/")
+    now = dt.datetime.now() + dt.timedelta(seconds=conf["expires"])
+    check_time = dt.datetime.strftime(now, "%a, %d %b %Y %H:%M:%S GMT")
+    check_cookie = f'{conf["key"]}={conf["value"]}; Domain={conf["domain"]}; expires={check_time}; HttpOnly; Max-Age={conf["max_age"]}; Path={conf["path"]}; SameSite={conf["samesite"]}; Secure'
+    assert response.headers["set-cookie"] == check_cookie
+
+
+def test_set_cookie_float():
+    import datetime as dt
+    conf = {
+        "key": "mycookie",
+        "value": "myvalue",
+        "max_age": 10,
+        "expires": 10.123,
+        "path": "/",
+        "domain": "localhost",
+        "secure": True,
+        "httponly": True,
+        "samesite": "none",
+    }
+
+    async def app(scope, receive, send):
+        response = Response("Hello, world!", media_type="text/plain")
+        response.set_cookie(
+            key=conf["key"],
+            value=conf["value"],
+            max_age=conf["max_age"],
+            expires=conf["expires"],
+            path=conf["path"],
+            domain=conf["domain"],
+            secure=conf["secure"],
+            httponly=conf["httponly"],
+            samesite=conf["samesite"],
+        )
+
+        await response(scope, receive, send)
+
+    client = TestClient(app)
+    response = client.get("/")
+    now = dt.datetime.now() + dt.timedelta(seconds=int(conf["expires"]))
+    check_time = dt.datetime.strftime(now, "%a, %d %b %Y %H:%M:%S GMT")
+    check_cookie = f'{conf["key"]}={conf["value"]}; Domain={conf["domain"]}; expires={check_time}; HttpOnly; Max-Age={conf["max_age"]}; Path={conf["path"]}; SameSite={conf["samesite"]}; Secure'
+    assert response.headers["set-cookie"] == check_cookie
+
+
 def test_delete_cookie():
     async def app(scope, receive, send):
         request = Request(scope, receive)


### PR DESCRIPTION
Currently a cookie expiry date is only allowed to be an integer.
For generating a time in the future one may wish to generate a
timedelta:

datetime.timedelta(days=14).total_seconds()

This, however, produces a float:

1209600.0

To prevent the user from having to cast to an int themselves, this merge
implements the ability to set a cookie expiry date from a float, where
it is then cast into an integer to be used as usual.